### PR TITLE
Fix serialization of undefined values

### DIFF
--- a/Erlang.js
+++ b/Erlang.js
@@ -29,6 +29,8 @@ var Erlang = this; // namespace
 
 var zlib = require('zlib');
 
+Erlang.undefinedAtom = 'undefined';
+
 // tag values here http://www.erlang.org/doc/apps/erts/erl_ext_dist.html
 var TAG_VERSION = 131;
 var TAG_COMPRESSED_ZLIB = 80;
@@ -92,7 +94,7 @@ var InputException = function InputException (message) {
     if (error.stack) {
         this.stack = error.stack;
     }
-}
+};
 InputException.prototype = Object.create(Error.prototype, {
     name: { value: 'InputException' }
 });
@@ -103,7 +105,7 @@ var OutputException = function OutputException (message) {
     if (error.stack) {
         this.stack = error.stack;
     }
-}
+};
 OutputException.prototype = Object.create(Error.prototype, {
     name: { value: 'OutputException' }
 });
@@ -114,7 +116,7 @@ var ParseException = function ParseException (message) {
     if (error.stack) {
         this.stack = error.stack;
     }
-}
+};
 ParseException.prototype = Object.create(Error.prototype, {
     name: { value: 'ParseException' }
 });
@@ -880,7 +882,7 @@ Erlang._term_to_binary = function _term_to_binary (term) {
                     throw new OutputException('unknown javascript object type');
             }
         case 'undefined':
-            return (new Erlang.OtpErlangAtom('nil')).binary();
+            return (new Erlang.OtpErlangAtom(Erlang.undefinedAtom)).binary();
         default:
             throw new OutputException('unknown javascript type');
     }

--- a/Erlang.js
+++ b/Erlang.js
@@ -879,6 +879,8 @@ Erlang._term_to_binary = function _term_to_binary (term) {
                 default:
                     throw new OutputException('unknown javascript object type');
             }
+        case 'undefined':
+            return (new Erlang.OtpErlangAtom('nil')).binary();
         default:
             throw new OutputException('unknown javascript type');
     }


### PR DESCRIPTION
Return undefined values as nil atom instead of crashing entire serialization call